### PR TITLE
Punctuation Fixes / Deadline Changes

### DIFF
--- a/onboarding.md
+++ b/onboarding.md
@@ -23,27 +23,11 @@ To facilitate your success, Casey will help you to plan your training, to devise
 
 **Deadlines:** Our lab has worked hard to develop a reputation for high-quality science that is well presented.
 We all benefit from this reputation, but we must also work to maintain it.
-In order to maintain the quality of our lab's output, we've established deadlines for various outputs.
-Each of these applies to sharing a complete version that the author deems ready for submission in the Greene Lab slack's `#general` channel.
+Abstracts for meetings must be shared with all co-authors, including Casey, at least one week prior to the deadline for submission.
+Failure to abide by this guideline will result in missing whatever the opportunity in question is.
 
-The specific deadlines for various types of outputs are:
-
-- Manuscripts must be shared two weeks before any deadlines.
-- Posters must be shared one week before the deadline for printing.
-- Scientific talks based on a submitted abstract must be shared one week before the presentation.
-- Meeting abstracts must be shared one week before the deadline for submission.
-
-Lab members are given a two-day period to provide feedback on the document.
-We expect that authors will then revise the document to incorporate feedback provided within the initial two-day period.
-Authors are encouraged but not required to address feedback received after the initial two days, as it may not always be practicable.
-
-This does not eliminate the need for all coauthors to approve a document.
-Coauthors are not required to provide their feedback within the two-day window.
-Coauthors can hold submission of a document until they approve; however, according to ICMJE guidelines extreme holds may result in a change from authorship to acknowledgement.
-
-In the case that all feedback received within the two-day period has been addressed and all coauthors approve, the submission can proceed.
-
-Failure to abide by these guidelines will result in missing whatever the opportunity in question is.
+Trainees in the lab will often receive opportunities to present their work at scientific conferences.
+These presentations reflect on the entire lab and must be presented to the research lab during a `braintrust` meeting prior to the conference, and lab members are expected to address feedback that is provided.
 
 **Code of Conduct:** All members of the lab, along with visitors, are expected to agree with this code of conduct.
 We will enforce this code.
@@ -51,14 +35,14 @@ We expect cooperation from all members to help ensuring a safe environment for e
 The lab is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, or religion (or lack thereof).
 We do not tolerate harassment of lab members in any form.
 Sexual language and imagery is generally not appropriate for any lab venue, including lab meetings, presentations, or discussions.
-However, do note that we work on biological matters so work-related discussions of e.g. animal reproduction are appropriate
-Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention
+However, do note that we work on biological matters so work-related discussions of e.g. animal reproduction are appropriate.
+Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
 Members asked to stop any harassing behavior are expected to comply immediately.
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact Casey Greene immediately
-If Casey is the cause of your concern, Dr. Deborah Hogan (<Deborah.A.Hogan@dartmouth.edu>) is a good informal point of contact; she does not work for Casey and has agreed to mediate
-For official concerns, please see the University of Pennsylvania ombuds office
-The code of conduct section is licensed under a Creative Commons Attribution 3.0 Unported License. <http://2012.jsconf.us/#/about> & The Ada Initiative
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact Casey Greene immediately.
+If Casey is the cause of your concern, Dr. Deborah Hogan (<Deborah.A.Hogan@dartmouth.edu>) is a good informal point of contact; she does not work for Casey and has agreed to mediate.
+For official concerns, please see the University of Pennsylvania ombuds office.
+The code of conduct section is licensed under a Creative Commons Attribution 3.0 Unported License. <http://2012.jsconf.us/#/about> & The Ada Initiative.
 Please help by translating or improving: <http://github.com/leftlogic/confcodeofconduct.com>.
 
 We expect members to follow these guidelines at any lab-related event.
@@ -66,12 +50,12 @@ We expect members to follow these guidelines at any lab-related event.
 **Authorship:** Our lab follows the [Perelman School of Medicine Authorship Policy](https://www.med.upenn.edu/policy/user_documents/2_Announcement_MemoLJLRE_PerelmanSchoolofMedicineAuthorshipPolicy.pdf)
 These guidelines are derived from ICMJE's Uniform Requirements for Manuscripts Submitted to Biomedical Journals.
 
-**Ethics:** We expect lab members to be honest in scientific communications both within and outside the lab
-We expect that lab members will design experiments in a manner that minimizes both bias and self deception
-We expect that lab members will keep agreements, be careful, and share their code and results openly with the scientific community
-We expect that credit will be given where credit is due, including in scientific writing
-Plagiarism is not tolerated
-While a full enumeration of ethical considerations is outside of the scope of this document, Penn provides a [handbook](https://provost.upenn.edu/uploads/media_items/ethics-handbook.original.pdf) that we recommend
+**Ethics:** We expect lab members to be honest in scientific communications both within and outside the lab.
+We expect that lab members will design experiments in a manner that minimizes both bias and self deception.
+We expect that lab members will keep agreements, be careful, and share their code and results openly with the scientific community.
+We expect that credit will be given where credit is due, including in scientific writing.
+Plagiarism is not tolerated.
+While a full enumeration of ethical considerations is outside of the scope of this document, Penn provides a [handbook](https://provost.upenn.edu/uploads/media_items/ethics-handbook.original.pdf) that we recommend.
 In addition, please don't hesitate to raise any questions or concerns that you have at any point with Casey.
 
 # Communication
@@ -114,7 +98,6 @@ Mandatory events such as lab meetings, scrums, and group deadlines go on Core Ev
 + GitHub (greenelab)
 + Google Calender (Shared Calendar)
 + Slack (GreeneLab)
-+ Dropbox (permanent members)
 
 ## Meetings
 

--- a/onboarding.md
+++ b/onboarding.md
@@ -47,7 +47,7 @@ Please help by translating or improving: <http://github.com/leftlogic/confcodeof
 
 We expect members to follow these guidelines at any lab-related event.
 
-**Authorship:** Our lab follows the [Perelman School of Medicine Authorship Policy](https://www.med.upenn.edu/policy/user_documents/2_Announcement_MemoLJLRE_PerelmanSchoolofMedicineAuthorshipPolicy.pdf)
+**Authorship:** Our lab follows the [Perelman School of Medicine Authorship Policy](https://www.med.upenn.edu/policy/user_documents/2_Announcement_MemoLJLRE_PerelmanSchoolofMedicineAuthorshipPolicy.pdf).
 These guidelines are derived from ICMJE's Uniform Requirements for Manuscripts Submitted to Biomedical Journals.
 
 **Ethics:** We expect lab members to be honest in scientific communications both within and outside the lab.

--- a/onboarding.md
+++ b/onboarding.md
@@ -27,7 +27,9 @@ Abstracts for meetings must be shared with all co-authors, including Casey, at l
 Failure to abide by this guideline will result in missing whatever the opportunity in question is.
 
 Trainees in the lab will often receive opportunities to present their work at scientific conferences.
-These presentations reflect on the entire lab and must be presented to the research lab during a `braintrust` meeting prior to the conference, and lab members are expected to address feedback that is provided.
+These presentations reflect on the entire lab.
+Oral presentations must be presented to the research lab during a `braintrust` meeting prior to the conference, and lab members are expected to address feedback that is provided.
+Poster presentations should be shared in the `#general` slack channel at least a week before printing.
 
 **Code of Conduct:** All members of the lab, along with visitors, are expected to agree with this code of conduct.
 We will enforce this code.


### PR DESCRIPTION
Fix some missing periods from the one-sentence-per-line conversion and adjust the deadlines to be narrower in scope.