### PR TITLE
update black version used for precommit

### DIFF
--- a/extras/linter_install_tutorial.md
+++ b/extras/linter_install_tutorial.md
@@ -22,7 +22,7 @@ This setup will also use the following packages (versions can be changed as need
 
 1. Set up your python environment to use python>=3.5 
 2. Call ``pip install pre-commit==2.9.3``
-3. call ``pip install black==20.8b1``
+3. call ``pip install black==22.3.0``
 4. Create a file with the extension .pre-commit-config.yaml and fill in with lines of code reproduced in the [Configuration Files](#Pre-commit) section
 5. Create a file with the extension .flake8 and fill in with lines of code reproduced in the [Configuration Files](#Flake8) section
 6. Create a file with the extension .toml and fill in with lines of code reproduced in the [Configuration Files](#Black) section


### PR DESCRIPTION
This PR updates the version of black used for the pre-commit @danich1 setup based on this [post](https://github.com/psf/black/issues/2964) after getting the following error message :
```
jupytext_auto_linter...........................
..........................Failed
- hook id: jupytext
- exit code: 1
[jupytext] Reading get-pheno-data.ipynb in
format ipynb
[jupytext] Updating notebook metadata with
'{"jupytext": {"formats": "ipynb,py"}}'
[jupytext] Executing black -
Traceback (most recent call last):
File
"/opt/homebrew/anaconda3/envs/env_precommit/bin
/black", line 8, in <module>
sys.exit(patched_main())
File
"/opt/homebrew/anaconda3/envs/env_precommit/lib
/python3.9/site-packages/black/__init__.py",
line 1055, in patched_main
patch_click()
File
"/opt/homebrew/anaconda3/envs/env_precommit/lib
/python3.9/site-packages/black/__init__.py",
line 1044, in patch_click
from click import _unicodefun # type:
ignore

ImportError: cannot import name '_unicodefun'
from 'click'
(/opt/homebrew/anaconda3/envs/env_precommit/lib
/python3.9/site-packages/click/__init__.py)
[jupytext] Error: The command 'black -' exited
with code 1
```